### PR TITLE
Use correct flag for derivative evaluation.

### DIFF
--- a/covfcs/stk_expcov_aniso.m
+++ b/covfcs/stk_expcov_aniso.m
@@ -108,7 +108,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_exponential (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_exponential (D, -1);
+    k = Sigma2 * stk_rbf_exponential (D, 1);
 elseif (diff >= 2) && (diff <= nb_params)
     %%% diff wrt param(diff) = - log(invRho(diff-1))
     ind = diff - 1;

--- a/covfcs/stk_expcov_iso.m
+++ b/covfcs/stk_expcov_iso.m
@@ -94,7 +94,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_exponential (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_exponential (D, -1);
+    k = Sigma2 * stk_rbf_exponential (D, 1);
 elseif diff == 2
     %%% diff wrt param(3) = - log(invRho)
     k = D .* (Sigma2 * stk_rbf_exponential (D, 1));

--- a/covfcs/stk_gausscov_aniso.m
+++ b/covfcs/stk_gausscov_aniso.m
@@ -108,7 +108,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_gauss (D, -1);
 elseif diff == 1
     % Differentiate wrt param(1) = log (Sigma2)
-    k = Sigma2 * stk_rbf_gauss (D, -1);
+    k = Sigma2 * stk_rbf_gauss (D, 1);
 elseif (diff >= 2) && (diff <= nb_params)
     % Differentiate wrt param(diff) = - log (invRho(diff-1))
     ind = diff - 1;

--- a/covfcs/stk_gausscov_iso.m
+++ b/covfcs/stk_gausscov_iso.m
@@ -93,7 +93,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_gauss (D, -1);
 elseif diff == 1
     % diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_gauss (D, -1);
+    k = Sigma2 * stk_rbf_gauss (D, 1);
 elseif diff == 2
     % diff wrt param(3) = - log(invRho)
     k = D .* (Sigma2 * stk_rbf_gauss (D, 1));

--- a/covfcs/stk_materncov32_aniso.m
+++ b/covfcs/stk_materncov32_aniso.m
@@ -109,7 +109,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern32 (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern32 (D, -1);
+    k = Sigma2 * stk_rbf_matern32 (D, 1);
 elseif (diff >= 2) && (diff <= nb_params)
     %%% diff wrt param(diff) = - log(invRho(diff-1))
     ind = diff - 1;

--- a/covfcs/stk_materncov32_iso.m
+++ b/covfcs/stk_materncov32_iso.m
@@ -94,7 +94,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern32 (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern32 (D, -1);
+    k = Sigma2 * stk_rbf_matern32 (D, 1);
 elseif diff == 2
     %%% diff wrt param(3) = - log(invRho)
     k = D .* (Sigma2 * stk_rbf_matern32 (D, 1));

--- a/covfcs/stk_materncov52_aniso.m
+++ b/covfcs/stk_materncov52_aniso.m
@@ -109,7 +109,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern52 (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern52 (D, -1);
+    k = Sigma2 * stk_rbf_matern52 (D, 1);
 elseif (diff >= 2) && (diff <= nb_params)
     %%% diff wrt param(diff) = - log(invRho(diff-1))
     ind = diff - 1;

--- a/covfcs/stk_materncov52_iso.m
+++ b/covfcs/stk_materncov52_iso.m
@@ -94,7 +94,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern52 (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern52 (D, -1);
+    k = Sigma2 * stk_rbf_matern52 (D, 1);
 elseif diff == 2
     %%% diff wrt param(3) = - log(invRho)
     k = D .* (Sigma2 * stk_rbf_matern52 (D, 1));

--- a/covfcs/stk_materncov_aniso.m
+++ b/covfcs/stk_materncov_aniso.m
@@ -111,7 +111,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern (Nu, D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern (Nu, D, -1);
+    k = Sigma2 * stk_rbf_matern (Nu, D, 1);
 elseif diff == 2
     %%% diff wrt param(2) = log(Nu)
     k = Nu * Sigma2 * stk_rbf_matern (Nu, D, 1);

--- a/covfcs/stk_materncov_iso.m
+++ b/covfcs/stk_materncov_iso.m
@@ -97,7 +97,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_matern (Nu, D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_matern (Nu, D, -1);
+    k = Sigma2 * stk_rbf_matern (Nu, D, 1);
 elseif diff == 2
     %%% diff wrt param(2) = log(Nu)
     k = Nu * Sigma2 * stk_rbf_matern (Nu, D, 1);

--- a/covfcs/stk_sphcov_aniso.m
+++ b/covfcs/stk_sphcov_aniso.m
@@ -108,7 +108,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_spherical (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_spherical (D, -1);
+    k = Sigma2 * stk_rbf_spherical (D, 1);
 elseif (diff >= 2) && (diff <= nb_params)
     %%% diff wrt param(diff) = - log(invRho(diff-1))
     ind = diff - 1;

--- a/covfcs/stk_sphcov_iso.m
+++ b/covfcs/stk_sphcov_iso.m
@@ -94,7 +94,7 @@ if diff == -1
     k = Sigma2 * stk_rbf_spherical (D, -1);
 elseif diff == 1
     %%% diff wrt param(1) = log(Sigma2)
-    k = Sigma2 * stk_rbf_spherical (D, -1);
+    k = Sigma2 * stk_rbf_spherical (D, 1);
 elseif diff == 2
     %%% diff wrt param(3) = - log(invRho)
     k = D .* (Sigma2 * stk_rbf_spherical (D, 1));


### PR DESCRIPTION
I believe the flag for evaluating the derivative is not being passed correctly to the correlation functions. Right now, there is no difference between passing `diff=0` and `diff=1` as options.