### PR TITLE
Fix more linter warnings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,16 @@
+2022-03-04  Julien Bect  <julien.bect@centralesupelec.fr>
+
+	Fix more linter warnings
+
+	* admin/stk_mlint_all.m: Display critical errors separately.  Add
+	'EXIST' and 'NOSEL' to the list of critical errors.
+	* misc/parallel/@stk_parallel_engine_parfor/stk_parallel_engine_parfor.m:
+	Fix warnings.
+	* misc/test/stk_isequal_tolabs.m: Idem.
+	* misc/test/stk_isequal_tolrel.m: Idem.
+	* misc/test/stk_test.m: Idem.
+	* sampling/stk_sampling_nestedlhs.m: Idem.
+
 2022-03-03  Julien Bect  <julien.bect@centralesupelec.fr>
 
 	stk_testfun_hartman4s.m: Scaled Hartman4 test function

--- a/admin/stk_mlint_all.m
+++ b/admin/stk_mlint_all.m
@@ -2,7 +2,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2021 CentraleSupelec
+%    Copyright (C) 2021, 2022 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -36,16 +36,33 @@ m = stk_mlint_all_ (root);
 
 % Linter messages that trigger a global error
 % (this list will be growing progressively)
-critical_errors = {'ISCLSTR', 'ISMT', 'MINV', 'MSNU', 'NOPAR', 'NOPAR2', ...
-    'NOPRT', 'RESWD', 'STREMP', 'STRIN', 'STTOK', 'TRYNC'};
+critical_errors = {'EXIST', 'ISCLSTR', 'ISMT', 'MINV', 'MSNU', 'NOPAR', ...
+    'NOPAR2', 'NOPRT', 'NOSEL', 'RESWD', 'STREMP', 'STRIN', 'STTOK', ...
+    'TRYNC'};
 
 b_ok = ~ any (ismember ({m.id}, critical_errors));
 
-% FIXME: Display critical errors separately
+% Summarize all linter warnings
 fprintf ('\n\nSUMMARY:\n')
 [msg, ~, ic] = unique ({m.id});
 for k = 1:(length (msg))
-    fprintf ('% 3d %s\n', sum (ic == k), msg{k});
+    if ismember (msg{k}, critical_errors)
+        s_crit = ' [CRITICAL]';
+    else
+        s_crit = '';
+    end
+    fprintf ('% 3d %s%s\n', sum (ic == k), msg{k}, s_crit);
+end
+
+% Display critical errors separately
+if ~ b_ok
+    fprintf ('\n\n CRITICAL ERRORS:\n\n');
+    for i = 1:(length (m))
+        if ismember (m(i).id, critical_errors)
+            disp (m(i));
+            fprintf ('\n');
+        end
+    end
 end
 
 end % function

--- a/misc/parallel/@stk_parallel_engine_parfor/stk_parallel_engine_parfor.m
+++ b/misc/parallel/@stk_parallel_engine_parfor/stk_parallel_engine_parfor.m
@@ -29,7 +29,7 @@
 
 function pareng = stk_parallel_engine_parfor()
 
-if exist ('parpool')
+if exist ('parpool')  %#ok<EXIST> 
     
     try
         parpool ();

--- a/misc/test/stk_isequal_tolabs.m
+++ b/misc/test/stk_isequal_tolabs.m
@@ -54,25 +54,25 @@ function res = stk_isequal_tolabs(a, b, tolabs)
 
 DEFAULT_TOLABS = 1e-8;
 
-if nargin == 2,
+if nargin == 2
     tolabs = DEFAULT_TOLABS;
 end
 
-if isstruct(a) && isstruct(b),
+if isstruct(a) && isstruct(b)
     
     L = fieldnames(a);
-    if ~isequal(fieldnames(b), L),
+    if ~ isequal (fieldnames(b), L)
         res = false;
         return;
     end
     res = true;
-    for k = 1:length(L),
-        if ~isfield(b, L{k}),
+    for k = 1:length(L)
+        if ~ isfield (b, L{k})
             res = false;
             return;
         end
         res = stk_isequal_tolabs(a.(L{k}), b.(L{k}), tolabs);
-        if ~ res,
+        if ~ res
             return;
         end
     end
@@ -87,8 +87,8 @@ elseif ischar (a) && ischar (b)
     
 elseif iscell (a) && iscell (b)
     
-    for i = 1:numel(a),
-        if ~stk_isequal_tolabs (a{i}, b{i}, tolabs);
+    for i = 1:numel(a)
+        if ~ stk_isequal_tolabs (a{i}, b{i}, tolabs)
             res = false;
             return;
         end

--- a/misc/test/stk_isequal_tolrel.m
+++ b/misc/test/stk_isequal_tolrel.m
@@ -58,20 +58,20 @@ function res = stk_isequal_tolrel(a, b, tolrel)
 
 DEFAULT_TOLREL = 1e-8;
 
-if nargin == 2,
+if nargin == 2
     tolrel = DEFAULT_TOLREL;
 end
 
-if isstruct(a) && isstruct(b),
+if isstruct(a) && isstruct(b)
     
     L = fieldnames(a);
-    if ~isequal(fieldnames(b), L),
+    if ~isequal(fieldnames(b), L)
         res = false;
         return;
     end
     res = true;
-    for k = 1:length(L),
-        if ~isfield(b, L{k}),
+    for k = 1:length(L)
+        if ~ isfield(b, L{k})
             res = false;
             return;
         end
@@ -96,8 +96,8 @@ elseif ischar (a) && ischar (b)
     
 elseif iscell (a) && iscell (b)
     
-    for i = 1:numel(a),
-        if ~ stk_isequal_tolrel (a{i}, b{i}, tolrel);
+    for i = 1:numel(a)
+        if ~ stk_isequal_tolrel (a{i}, b{i}, tolrel)
             res = false;
             return;
         end

--- a/misc/test/stk_test.m
+++ b/misc/test/stk_test.m
@@ -177,7 +177,7 @@ if (iscell (x__file))
     end
 end
 if (isempty (x__file))
-    if (exist (x__name) == 3)
+    if (exist (x__name) == 3)  %#ok<EXIST> 
         fprintf (x__fid, '%s%s source code with tests for dynamically linked function not found\n', SIGNAL_EMPTY, x__name);
     else
         fprintf (x__fid, '%s%s does not exist in path\n', SIGNAL_EMPTY, x__name);

--- a/sampling/stk_sampling_nestedlhs.m
+++ b/sampling/stk_sampling_nestedlhs.m
@@ -165,7 +165,7 @@ quotient = [1; quotient];	% no multiplication at the first level
 row_highLevels   = @(M, k, numb)(numb(M) - ( (numb(k) - 1):-1:0));
 row_currentLevel = @(M, k, numb)(numb(M) - ( (numb(k) - 1):-1:numb(k + 1)) );
 
-for k_lev = nLev:-1:1; %begin by the end
+for k_lev = nLev:-1:1  % Begin by the end
     
     list_nb = (1:n(k_lev))';           % list of all values we must get after this loop
     n_new_k = n(k_lev) - n(k_lev + 1);	% number of new value to add


### PR DESCRIPTION
* `admin/stk_mlint_all.m`: Display critical errors separately.  Add
  'EXIST' and 'NOSEL' to the list of critical errors.
* `misc/parallel/@stk_parallel_engine_parfor/stk_parallel_engine_parfor.m`:
  Fix warnings.
* `misc/test/stk_isequal_tolabs.m`: Idem.
* `misc/test/stk_isequal_tolrel.m`: Idem.
* `misc/test/stk_test.m`: Idem.
* `sampling/stk_sampling_nestedlhs.m`: Idem.