### PR TITLE
Hartman3 & other improvements to example/testfunctions

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,26 @@
+2022-12-16  Julien Bect  <julien.bect@centralesupelec.fr>
+
+	More Hartman functions
+
+	* examples/test_functions/stk_testfun_hartman_generic.m: Generic
+	implementation of Hartman functions (Dixon-Szego diagonal form).
+	* examples/test_functions/stk_testfun_hartman3.m: New function.
+	* examples/test_functions/stk_testfun_hartman4.m: Rewrite using generic.
+	* examples/test_functions/stk_testfun_hartman6.m: Rewrite using generic.
+	* admin/octpkg/INDEX: Update Octave package index.
+
+	CC0 licence for some existing test functions
+
+	* examples/test_functions/stk_testfun_braninhoo.m: Apply CC0.
+	* examples/test_functions/stk_testfun_twobumps.m: Reformat existing header.
+	* examples/test_functions/stk_testcase_truss3.m: Idem.
+	* examples/test_functions/stk_testfun_truss3_bb.m: Idem.
+	* examples/test_functions/stk_testfun_truss3_vol.m: Idem.
+
+	stk_testcase_truss3.m: Polish help text
+
+	* examples/test_functions/stk_testcase_truss3.m: Polish help text.
+
 2022-12-13  Julien Bect  <julien.bect@centralesupelec.fr>
 
 	.github/workflows: Use Matlab R2022b as well

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,11 +17,15 @@
 
 ## Test functions
 
+* `stk_testfun_hartman3.m`, `stk_testfun_hartman6.m`: New test
+  functions ("Hartman3" and "Hartman6") from the Dixon & Szego (1978)
+  benchmark.
+
 * `stk_testfun_hartman4.m`: New test function ("Hartman4") based on
   Picheny et al (2013), with a different scaling.
 
-* `stk_testfun_hartman6.m`: New test function ("Hartman6") from the
-  Dixon & Szego (1978) benchmark.
+* Most test functions in `examples/test_functions` are now also
+  available under the CC0 license (see each file).
 
 -----
 

--- a/admin/octpkg/INDEX
+++ b/admin/octpkg/INDEX
@@ -305,8 +305,10 @@ Examples: test functions, datasets, etc.
  stk_testfun_borehole
  stk_testfun_braninhoo
  stk_testfun_goldsteinprice
+ stk_testfun_hartman3
  stk_testfun_hartman4
  stk_testfun_hartman6
+ stk_testfun_hartman_generic
  stk_testfun_twobumps
  stk_testcase_truss3
  stk_testfun_truss3_bb

--- a/examples/test_functions/stk_testcase_truss3.m
+++ b/examples/test_functions/stk_testcase_truss3.m
@@ -7,8 +7,8 @@
 %
 %     * .constants: all the numerical constants for this problem,
 %
-%     * .search_domain: an stk_hrect object that specifies the search domain
-%       of the optimization problem.
+%     * .search_domain: an stk_hrect object that specifies the search
+%       domain of the optimization problem.
 %
 % TEST CASE OVERVIEW
 %
@@ -23,16 +23,18 @@
 %                   (1)  \_  |  __/   (3)       |
 %                          \_P_/                v
 %
-%    Nodes A, B and C are fixed (pin joints).  Node P is submitted to both an
-%    horizontal load F1 (e.g., wind) and a vertical load F2 (suspended load).
+%    Nodes A, B and C are fixed (pin joints).  Node P is submitted to both
+%    an horizontal load F1 (e.g., wind) and a vertical load F2 (suspended
+%    load).
 %
 %    The design variables are the cross-sections a1, a2 and a3 of the three
-%    bars, and the horizontal position w of the vertical bar.  The quantities
-%    of interest are the total volume of the structure, the mechanical
-%    (tensile) stress in the bars, and the displacement of P.  Various
-%    formulations of optimization problems can be considered, depending on
-%    which quantities are selected as contraints and objectives, and whether
-%    or not uncertainties are taken into account (robust formulations).
+%    bars, and the horizontal position w of the vertical bar.  The
+%    quantities of interest are the total volume of the structure, the
+%    mechanical (tensile) stress in the bars, and the displacement of P.
+%    Various formulations of optimization problems can be considered,
+%    depending on which quantities are selected as contraints and
+%    objectives, and whether or not uncertainties are taken into account
+%    (robust formulations).
 %
 % NUMERICAL CONSTANTS
 %
@@ -53,18 +55,18 @@
 %     * .F2_mean: mean (nominal) value of the vertical load [N]
 %     *  .F2_std: standard deviation of the vertical load [N].
 %
-%    The standard deviations .F1_std and .F2_std are used in the formulation
-%    of robust optimization problems related to this test case [see 1, chap 11].
+%    The standard deviations F1_std and F2_std are used in the formulation
+%    of robust optimization problems [see 1, chap 11].
 %    
 % NUMERICAL FUNCTIONS
 %
-%    Two numerical functions are provided to compute the quantities of interest
-%    of this test case:
+%    Two numerical functions are provided to compute the quantities of
+%    interest of this test case:
 %
 %     * stk_testfun_truss3_vol: computes the total volume of the structure,
 %
-%     * stk_testfun_truss3_bb: computes the tensile stress in the bars and the
-%       displacement of P.
+%     * stk_testfun_truss3_bb: computes the tensile stress in the bars and
+%       the displacement of P.
 %
 %    Both functions have the same syntax:
 %
@@ -72,11 +74,12 @@
 %
 %       Z = stk_testfun_truss3_bb (X, CONST)
 %
-%    where CONST is a structure containing the necessary numerical constants.
-%    To use the constants from [1], pass TC.constants as second input argument.
+%    where CONST is a structure containing the necessary numerical
+%    constants.  To use the constants from [1], pass TC.constants as
+%    second input argument.
 %
-%    Both function accept as first input argument an N x D matrix (or data
-%    frame) where D is either 4 or 6:
+%    Both functions accept as first input argument an N x D matrix
+%    (or data frame) where D is either 4 or 6:
 %
 %     * columns 1--3: cross-section a1, a2 and a3,
 %
@@ -84,9 +87,9 @@
 %
 %     * column 5-6 (optional): horizontal and vertical loads F1, F2.
 %
-%    The second function is named 'bb' for 'black box', as it plays the role of
-%    a (supposedly expensive to evaluate) black box computer model for this
-%    test case.  The output Z has five columns, corresponding to:
+%    The second function is named 'bb' for 'black box', as it plays the
+%    role of a (supposedly expensive to evaluate) black box computer model
+%    for this test case.  The output Z has five columns, corresponding to:
 %
 %     * columns 1--2: horizontal and vertical displacement y1, y2 of P,
 %
@@ -124,6 +127,18 @@
 %      Biomedical Engineering,  1(6):333-337,  1985.
 %
 % See also: stk_testfun_truss3_vol, stk_testfun_truss3_bb
+
+% Author
+%
+%    Julien Bect  <julien.bect@centralesupelec.fr>
+
+% Copying Permission Statement  (this file)
+%
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testcase_truss3.m.  This work is published from France.
+%
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
 
 % Copyright Notice
 %

--- a/examples/test_functions/stk_testfun_braninhoo.m
+++ b/examples/test_functions/stk_testfun_braninhoo.m
@@ -15,13 +15,19 @@
 %  [2] Dixon L.C.W., Szego G.P., Towards Global Optimization 2, North-
 %      Holland, Amsterdam, The Netherlands (1978)
 
-% Copyright Notice
+% Author
 %
-%    Copyright (C) 2012-2014 SUPELEC
-%
-%    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
+%    Julien Bect  <julien.bect@centralesupelec.fr>
 
-% Copying Permission Statement
+% Copying Permission Statement  (this file)
+%
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_braninhoo.m.  This work is published from France.
+%
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
+
+% Copying Permission Statement  (STK toolbox as a whole)
 %
 %    This file is part of
 %

--- a/examples/test_functions/stk_testfun_goldsteinprice.m
+++ b/examples/test_functions/stk_testfun_goldsteinprice.m
@@ -49,7 +49,7 @@
 
 function y = stk_testfun_goldsteinprice (x)
 
-if nargin == 0,
+if nargin == 0
     visu_goldsteinprice ();
     return;
 end

--- a/examples/test_functions/stk_testfun_hartman3.m
+++ b/examples/test_functions/stk_testfun_hartman3.m
@@ -1,9 +1,9 @@
-% STK_TESTFUN_HARTMAN6 computes the "Hartman6" function
+% STK_TESTFUN_HARTMAN3 computes the "Hartman3" function
 %
-%    The Hartman6 function is a test function in dimension 6, which is
+%    The Hartman3 function is a test function in dimension 3, which is
 %    part of the famous Dixon & Szego benchmark [1] in global optimization.
 %
-%    It is usually minimized over [0, 1]^6.
+%    It is usually minimized over [0, 1]^3.
 %
 % HISTORICAL REMARKS
 %
@@ -11,26 +11,25 @@
 %    introduced by Hartman [2], hence the name.
 %
 %    The particular set of coefficients used in the definition of the
-%    "Hartman6" function, however, seems to have been introduced by [1].
+%    "Hartman3" function, however, seems to have been introduced by [1].
 %
 % GLOBAL MINIMUM
 %
-%    According to [4], the function has one global minimum at
+%    According to [5], the function has one global minimum at
 %
-%       x = [0.20169 0.150011 0.476874 0.275332 0.311652 0.657300].
-%
-%    The corresponding function value is:
-%
-%       f(x) = -3.322368011391339
-%
-%    A slightly lower value is attained [5] at
-%
-%       x = [0.20168952 0.15001069 0.47687398 ...
-%            0.27533243 0.31165162 0.65730054]
+%       x = [0.1, 0.55592003, 0.85218259].
 %
 %    The corresponding function value is:
 %
-%       f(x) = -3.322368011415512
+%       f(x) = -3.862634748621772.
+%
+%    A slightly lower value is attained [4] at
+%
+%       x = [0.114614 0.554649 0.852547].
+%
+%    The corresponding function value is:
+%
+%       f(x) = -3.862747199255087
 %
 %    The exact global optimum does not appear to be known.
 %
@@ -62,7 +61,7 @@
 %
 %    To the extent possible under law, CentraleSupélec has waived all
 %    copyright and related or neighboring rights to
-%    stk_testfun_hartman6.m.  This work is published from France.
+%    stk_testfun_hartman3.m.  This work is published from France.
 %
 %    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
 
@@ -86,23 +85,17 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function y = stk_testfun_hartman6 (x)
+function y = stk_testfun_hartman3 (x)
 
-a = [                               ...
-    [ 10.00   0.05   3.00  17.00 ]; ...
-    [  3.00  10.00   3.50   8.00 ]; ...
-    [ 17.00  17.00   1.70   0.05 ]; ...
-    [  3.50   0.10  10.00  10.00 ]; ...
-    [  1.70   8.00  17.00   0.10 ]; ...
-    [  8.00  14.00   8.00  14.00 ]];
+a = [                          ...
+    [  3.0   0.1   3.0   0.1]; ...
+    [ 10.0  10.0  10.0  10.0]; ...
+    [ 30.0  35.0  30.0  35.0]];
 
 p = [                                   ...
-    [ 0.1312  0.2329  0.2348  0.4047 ]; ...
-    [ 0.1696  0.4135  0.1451  0.8828 ]; ...
-    [ 0.5569  0.8307  0.3522  0.8732 ]; ...
-    [ 0.0124  0.3736  0.2883  0.5743 ]; ...
-    [ 0.8283  0.1004  0.3047  0.1091 ]; ...
-    [ 0.5886  0.9991  0.6650  0.0381 ]];
+    [ 0.3689  0.4699  0.1091  0.03815]; ...
+    [ 0.1170  0.4387  0.8732  0.57430]; ...
+    [ 0.2673  0.7470  0.5547  0.88280]];
 
 c = [1.0  1.2  3.0  3.2];
 
@@ -112,11 +105,11 @@ end % function
 
 
 %!test
-%! x1 = [0.20169 0.150011 0.476874 0.275332 0.311652 0.657300];
-%! y1 = -3.322368011391339;
+%! x1 = [0.1, 0.55592003, 0.85218259];
+%! y1 = -3.862634748621772;
 %!
-%! x2 = [0.20168952 0.15001069 0.47687398 0.27533243 0.31165162 0.65730054];
-%! y2 = -3.322368011415512;
+%! x2 = [0.114614 0.554649 0.852547];
+%! y2 = -3.862747199255087;
 %!
-%! y = stk_testfun_hartman6 ([x1; x2]);
+%! y = stk_testfun_hartman3 ([x1; x2]);
 %! assert (stk_isequal_tolabs (y, [y1; y2], 1e-15))

--- a/examples/test_functions/stk_testfun_hartman4.m
+++ b/examples/test_functions/stk_testfun_hartman4.m
@@ -26,15 +26,6 @@
 %    the sum at the fourth coordinate in the six-dimensional Hartman
 %    function of [3].
 %
-% IMPLEMENTATION
-%
-%    This implementation has been written from scratch using [2] as a
-%    reference, and then checked for correctness with respect to [4, 5].
-%
-%    Only minor differences, of the order of 1e-15, were observed with
-%    respect to [5].  The implementation in [4], however, uses a different
-%    scaling: the leading term is 1/0.8387 instead of 1/0.839 in [2, 5].
-%
 % GLOBAL MINIMUM
 %
 %    According to [4], the function has one global minimum at
@@ -70,18 +61,20 @@
 %  [4] V. Picheny, D. Ginsbourger & O. Roustant (2021).  DiceOptim:
 %      Kriging-Based Optimization for Computer Experiments.  R package
 %      version 2.1.1.  URL: https://CRAN.R-project.org/package=DiceOptim.
-%
-%  [5] S. Surjanovic & D. Bingham.  Virtual Library of Simulation
-%      Experiments: Test Functions and Datasets.  Retrieved March 3,
-%      2022, https://www.sfu.ca/~ssurjano/hart4.html.
 
-% Copyright Notice
+% Author
 %
-%    Copyright (C) 2022 CentraleSupelec
-%
-%    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
+%    Julien Bect  <julien.bect@centralesupelec.fr>
 
-% Copying Permission Statement (STK toolbox as a whole)
+% Copying Permission Statement  (this file)
+%
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_hartman4.m.  This work is published from France.
+%
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
+
+% Copying Permission Statement  (STK toolbox as a whole)
 %
 %    This file is part of
 %
@@ -101,64 +94,23 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-% Copying Permission Statement (this file)
-%
-%    Redistribution and use  in source and binary forms,  with or without
-%    modification,  are permitted provided that  the following conditions
-%    are met:
-%
-%    1. Redistributions  of source code  must retain  the above copyright
-%       notice,  this list of conditions and the following disclaimer.
-%
-%    2. Redistributions in binary form must reproduce the above copyright
-%       notice,  this list of conditions  and the following disclaimer in
-%       the documentation   and/or   other materials  provided  with  the
-%       distribution.
-%
-%    3. Neither  the name  of the copyright holder  nor the names  of its
-%       contributors may be used  to endorse or promote products  derived
-%       from this software  without specific prior written permission.
-%
-%    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS  AND CONTRIBUTORS
-%    "AS IS" AND ANY EXPRESS  OR IMPLIED WARRANTIES,  INCLUDING,  BUT NOT
-%    LIMITED TO,  THE IMPLIED WARRANTIES  OF MERCHANTABILITY  AND FITNESS
-%    FOR A  PARTICULAR PURPOSE  ARE DISCLAIMED.  IN  NO EVENT  SHALL  THE
-%    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-%    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-%    BUT NOT  LIMITED TO,  PROCUREMENT  OF SUBSTITUTE GOODS  OR SERVICES;
-%    LOSS OF USE,  DATA,  OR PROFITS;  OR BUSINESS INTERRUPTION)  HOWEVER
-%    CAUSED AND ON ANY THEORY OF LIABILITY,  WHETHER IN CONTRACT,  STRICT
-%    LIABILITY,  OR TORT (INCLUDING NEGLIGENCE  OR OTHERWISE)  ARISING IN
-%    ANY WAY  OUT OF THE USE  OF THIS SOFTWARE,  EVEN  IF ADVISED  OF THE
-%    POSSIBILITY OF SUCH DAMAGE.
-
 function y = stk_testfun_hartman4 (x)
 
-x = double (x);
-
-assert (size (x, 2) == 4);
-
-A = [                               ...
+a = [                               ...
     [ 10.00   0.05   3.00  17.00 ]; ...
     [  3.00  10.00   3.50   8.00 ]; ...
     [ 17.00  17.00   1.70   0.05 ]; ...
     [  3.50   0.10  10.00  10.00 ]];
 
-P = [                                  ...
+p = [                                  ...
     [ 0.1312  0.2329  0.2348  0.4047]; ...
     [ 0.1696  0.4135  0.1451  0.8828]; ...
     [ 0.5569  0.8307  0.3522  0.8732]; ...
     [ 0.0124  0.3736  0.2883  0.5743]];
 
-C = [1.0  1.2  3.0  3.2];
+c = [1.0  1.2  3.0  3.2];
 
-% Compute inner sum
-inner_sum = sum ( ...
-    bsxfun (@times, shiftdim (A, -1), ...
-    (bsxfun (@minus, x, shiftdim (P, -1))) .^ 2), 2);
-
-% Compute the outer sum
-y = - sum (bsxfun (@times, shiftdim (C, -1), exp (- inner_sum)), 3);
+y = stk_testfun_hartman_generic (x, a, p, c);
 
 end % function
 

--- a/examples/test_functions/stk_testfun_hartman_generic.m
+++ b/examples/test_functions/stk_testfun_hartman_generic.m
@@ -1,0 +1,103 @@
+% STK_TESTFUN_HARTMAN_GENERIC compute the value of a Hartman function
+%
+% CALL: Y = stk_testfun_hartman_generic (X, A, P, C)
+% 
+%    computes the value Y of the Hartman function with parameters A, P, C,
+%    at the points contained in X.
+%
+%    The size of Y is N x 1, where N is the number of rows of X.
+%
+%    The parameters A, P and C should have size N x D, N x D and 1 x D
+%    respectively, where D is the number of columns of X.
+%
+% HISTORICAL NOTE
+%
+%    This class of test functions has been introduced by Hartman [2],
+%    hence the name.  The particular form of Hartman functions considered
+%    here, however, seems to have been introduced by [1].
+%
+%    The only difference between the particular form considered in [1] and
+%    the general form in [2] is that the weighting matrix for the quadratic
+%    form in the exponential is assumed to be diagonal.
+%
+% REFERENCES
+%
+%  [1] L. C. W. Dixon & G. P. Szego (1978).  Towards Global
+%      Optimization 2, North-Holland, Amsterdam, The Netherlands
+%
+%  [2] J. K. Hartman (1973).  Some experiments in global optimization.
+%      Naval Research Logistics Quarterly, 20(3):569-576.
+%
+%  [3] V. Picheny, T. Wagner & D. Ginsbourger (2013).  A benchmark
+%      of kriging-based infill criteria for noisy optimization.
+%      Structural and Multidisciplinary Optimization, 48:607-626.
+%
+%  [4] MCS: Global Optimization by Multilevel Coordinate Search.
+%      Version 2.0 from Feb. 8, 2000.  Retrieved on March 10, 2022,
+%      from https://www.mat.univie.ac.at/~neum/software/mcs/
+%
+%  [5] S. Surjanovic & D. Bingham.  Virtual Library of Simulation
+%      Experiments: Test Functions and Datasets.  Retrieved March 3,
+%      2022, https://www.sfu.ca/~ssurjano/hart4.html.
+%
+% See also stk_testfun_hartman3, stk_testfun_hartman4, stk_testfun_hartman6
+
+% Author
+%
+%    Julien Bect  <julien.bect@centralesupelec.fr>
+
+% IMPLEMENTATION
+%
+%    This implementation has been written from scratch using [1, 3] as
+%    references (omitting the scaling in [3]).  Other implementations
+%    available on the web, such as [4, 5], have only been used to check
+%    the results for some special cases (Hartman3 and Hartman6 functions).
+
+% Copying Permission Statement  (this file)
+%
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_hartman_generic.m.  This work is published from France.
+%
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
+
+% Copying Permission Statement  (STK toolbox as a whole)
+%
+%    This file is part of
+%
+%            STK: a Small (Matlab/Octave) Toolbox for Kriging
+%               (https://github.com/stk-kriging/stk/)
+%
+%    STK is free software: you can redistribute it and/or modify it under
+%    the terms of the GNU General Public License as published by the Free
+%    Software Foundation,  either version 3  of the License, or  (at your
+%    option) any later version.
+%
+%    STK is distributed  in the hope that it will  be useful, but WITHOUT
+%    ANY WARRANTY;  without even the implied  warranty of MERCHANTABILITY
+%    or FITNESS  FOR A  PARTICULAR PURPOSE.  See  the GNU  General Public
+%    License for more details.
+%
+%    You should  have received a copy  of the GNU  General Public License
+%    along with STK.  If not, see <http://www.gnu.org/licenses/>.
+
+function y = stk_testfun_hartman_generic (x, A, P, C)
+
+x = double (x);
+
+d = size (x, 2);
+m = size (A, 2);
+
+assert (isequal (size (A), [d m]));
+assert (isequal (size (P), [d m]));
+assert (isequal (size (C), [1 m]));
+
+% Compute inner sum
+inner_sum = sum ( ...
+    bsxfun (@times, shiftdim (A, -1), ...
+    (bsxfun (@minus, x, shiftdim (P, -1))) .^ 2), 2);
+
+% Compute the outer sum
+y = - sum (bsxfun (@times, shiftdim (C, -1), exp (- inner_sum)), 3);
+
+end % function

--- a/examples/test_functions/stk_testfun_truss3_bb.m
+++ b/examples/test_functions/stk_testfun_truss3_bb.m
@@ -4,20 +4,17 @@
 %
 % See also: stk_testcase_truss3, stk_testfun_truss3_vol
 
-% Copyright Notice
+% Author
 %
-%    This file: stk_testfun_truss3_bb.m was written in 2017
-%                        by Julien Bect <julien.bect@centralesupelec.fr>.
+%    Julien Bect  <julien.bect@centralesupelec.fr>
+
+% Copying Permission Statement  (this file)
 %
-%    To the extent possible under law,  the author(s)  have dedicated all
-%    copyright and related and neighboring rights to this file to the pub-
-%    lic domain worldwide. This file is distributed without any warranty.
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_truss3_bb.m.  This work is published from France.
 %
-%    This work is published from France.
-%
-%    You should have received a copy of the  CC0 Public Domain Dedication
-%    along with this file.  If not, see
-%                    <http://creativecommons.org/publicdomain/zero/1.0/>.
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
 
 % Copying Permission Statement (STK toolbox as a whole)
 %

--- a/examples/test_functions/stk_testfun_truss3_vol.m
+++ b/examples/test_functions/stk_testfun_truss3_vol.m
@@ -4,21 +4,17 @@
 %
 % See also: stk_testcase_truss3, stk_testfun_truss3_bb
 
+% Author
+%
+%    Julien Bect  <julien.bect@centralesupelec.fr>
 
-% Copyright Notice
+% Copying Permission Statement  (this file)
 %
-%    This file: stk_testfun_truss3_vol.m was written in 2017
-%                        by Julien Bect <julien.bect@centralesupelec.fr>.
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_truss3_vol.m.  This work is published from France.
 %
-%    To the extent possible under law,  the author(s)  have dedicated all
-%    copyright and related and neighboring rights to this file to the pub-
-%    lic domain worldwide. This file is distributed without any warranty.
-%
-%    This work is published from France.
-%
-%    You should have received a copy of the  CC0 Public Domain Dedication
-%    along with this file.  If not, see
-%                    <http://creativecommons.org/publicdomain/zero/1.0/>.
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
 
 % Copying Permission Statement (STK toolbox as a whole)
 %

--- a/examples/test_functions/stk_testfun_twobumps.m
+++ b/examples/test_functions/stk_testfun_twobumps.m
@@ -10,17 +10,20 @@
 %
 %    for x in [-1.0; 1.0].
 
-% Copyright Notice
+% Authors
 %
-%    Copyright (C) 2016 CentraleSupelec
-%
-%    Authors:  Julien Bect       <julien.bect@centralesupelec.fr>
-%              Emmanuel Vazquez  <emmanuel.vazquez@centralesupelec.fr>
-%
-%    This response function (its opposite, actually) has been present as an
-%    example in the STK toolbox since the very first releases (STK 1.0, 2011).
+%    Julien Bect       <julien.bect@centralesupelec.fr>
+%    Emmanuel Vazquez  <emmanuel.vazquez@centralesupelec.fr>
 
-% Copying Permission Statement  (STK toolbox)
+% Copying Permission Statement  (this file)
+%
+%    To the extent possible under law, CentraleSupélec has waived all
+%    copyright and related or neighboring rights to
+%    stk_testfun_twobumps.m.  This work is published from France.
+%
+%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
+
+% Copying Permission Statement  (STK toolbox as a whole)
 %
 %    This file is part of
 %
@@ -39,14 +42,6 @@
 %
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
-
-% Copying Permission Statement  (this file)
-%
-%    To the extent possible under law,  Julien Bect  and Emmanuel Vazquez
-%    have waived  all copyright  and related  or neighboring rights to
-%    stk_testfun_twobumps.m.  This work is published from France.
-%
-%    License: CC0  <http://creativecommons.org/publicdomain/zero/1.0/>
 
 function z = stk_testfun_twobumps (x)
 


### PR DESCRIPTION
More Hartman functions

* examples/test_functions/stk_testfun_hartman_generic.m: Generic implementation of Hartman functions (Dixon-Szego diagonal form).
* examples/test_functions/stk_testfun_hartman3.m: New function.
* examples/test_functions/stk_testfun_hartman4.m: Rewrite using generic.
* examples/test_functions/stk_testfun_hartman6.m: Rewrite using generic.
* admin/octpkg/INDEX: Update Octave package index.

CC0 licence for some existing test functions

* examples/test_functions/stk_testfun_braninhoo.m: Apply CC0.
* examples/test_functions/stk_testfun_twobumps.m: Reformat existing header.

stk_testcase_truss3.m: Polish help text

* examples/test_functions/stk_testcase_truss3.m: Polish help text.