### PR TITLE
stk_covmat_noise.m: Remove unused outputs P1, P2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,14 @@
+2023-09-11  Julien Bect  <julien.bect@centralesupelec.fr>
+
+	stk_covmat_noise.m: Remove unused outputs P1, P2
+
+	* model/@stk_model_/stk_covmat_noise.m: Remove unused outputs P1, P2.
+	* model/@stk_model_gpposterior/stk_covmat_noise.m: Idem.
+	* model/noise/@stk_gaussiannoise_/stk_covmat_noise.m: Idem.
+	* model/prior_struct/stk_covmat_noise.m: Idem.
+
+	[Changes imported manually from branch `lm-param`, written in 2021.]
+
 2023-06-25  Julien Bect  <julien.bect@centralesupelec.fr>
 
 	@stk_optim_octavesq: Catch sqp error (closes tickets #38 and #39)

--- a/model/@stk_model_/stk_covmat_noise.m
+++ b/model/@stk_model_/stk_covmat_noise.m
@@ -2,7 +2,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2019, 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,11 +26,10 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, x1, x2, diff, pairwise)
+function K = stk_covmat_noise (model, x1, x2, diff, pairwise)
 
 stk_error (['Classes derived from stk_model_ must implement ' ...
     'stk_covmat_noise.'], 'IncompleteClassImplementation');
-
 
 end % function
 

--- a/model/@stk_model_gpposterior/stk_covmat_noise.m
+++ b/model/@stk_model_gpposterior/stk_covmat_noise.m
@@ -2,7 +2,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2019, 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,21 +26,9 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, varargin)
+function K = stk_covmat_noise (model, varargin)
 
-if nargout <= 1
-    
-    K = stk_covmat_noise (model.prior, varargin{:});
-    
-elseif nargout == 2
-    
-    [K, P1] = stk_covmat_noise (model.prior, varargin{:});
-    
-else
-    
-    [K, P1, P2] = stk_covmat_noise (model.prior, varargin{:});
-    
-end
+K = stk_covmat_noise (model.prior, varargin{:});
 
 end % function
 

--- a/model/noise/@stk_gaussiannoise_/stk_covmat_noise.m
+++ b/model/noise/@stk_gaussiannoise_/stk_covmat_noise.m
@@ -2,7 +2,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2019 CentraleSupelec
+%    Copyright (C) 2019, 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -26,21 +26,9 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function [K, P1, P2] = stk_covmat_noise (model, varargin)
+function K = stk_covmat_noise (model, varargin)
 
-if nargout <= 1
-    
-    K = stk_covmat (model, varargin{:});
-    
-elseif nargout == 2
-    
-    [K, P1] = stk_covmat (model, varargin{:});
-    
-else
-    
-    [K, P1, P2] = stk_covmat (model, varargin{:});
-    
-end
+K = stk_covmat (model, varargin{:});
 
 end % function
 


### PR DESCRIPTION
* model/@stk_model_/stk_covmat_noise.m: Remove unused outputs P1, P2.
* model/@stk_model_gpposterior/stk_covmat_noise.m: Idem.
* model/noise/@stk_gaussiannoise_/stk_covmat_noise.m: Idem.
* model/prior_struct/stk_covmat_noise.m: Idem.

[Changes imported manually from branch `lm-param`, written in 2021.]