### PR TITLE
stk_nullcov: New function, which computes a null covariance matrix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 2023-09-11  Julien Bect  <julien.bect@centralesupelec.fr>
 
+	stk_nullcov.m: New function, which computes a null covariance matrix
+
+	* stk_nullcov.m: New function, which computes a null covariance matrix.
+	* model/prior_struct/stk_covmat_noise.m: Use `stk_nullcov`.
+	* admin/octpkg/INDEX: Update Octave package index.
+	* NEWS.md: Advertise the change.
+
+	[Changes imported manually from branch `lm-param`, written in 2021.]
+
+2023-09-11  Julien Bect  <julien.bect@centralesupelec.fr>
+
 	stk_covmat_noise.m: Remove unused outputs P1, P2
 
 	* model/@stk_model_/stk_covmat_noise.m: Remove unused outputs P1, P2.

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,10 @@
 
 * `stk_example_misc06`: New example.
 
+## Covariance functions
+
+* `stk_nullcov`: New function, which computes a null covariance matrix.
+
 -----
 
 

--- a/admin/octpkg/INDEX
+++ b/admin/octpkg/INDEX
@@ -158,6 +158,7 @@ Model components: covariance functions
  stk_materncov52_iso
  stk_materncov_aniso
  stk_materncov_iso
+ stk_nullcov
  stk_sphcov_aniso
  stk_sphcov_iso
  stk_discretecov

--- a/covfcs/stk_nullcov.m
+++ b/covfcs/stk_nullcov.m
@@ -1,0 +1,60 @@
+% STK_NULLCOV computes a null covariance matrix
+%
+% The syntax is similar to other STK covariance functions.
+%
+% CALL: K = stk_nullcov (PARAM, X, Y)
+%
+% CALL: dK = stk_nullcov (PARAM, X, Y, DIFF)
+%
+% CALL: K = stk_nullcov (PARAM, X, Y, DIFF, PAIRWISE)
+%
+% where PARAM should be [].
+
+% Copyright Notice
+%
+%    Copyright (C) 2021 CentraleSupelec
+%
+%    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
+
+% Copying Permission Statement
+%
+%    This file is part of
+%
+%            STK: a Small (Matlab/Octave) Toolbox for Kriging
+%                 (https://github.com/stk-kriging/stk/)
+%
+%    STK is free software: you can redistribute it and/or modify it under
+%    the terms of the GNU General Public License as published by the Free
+%    Software Foundation,  either version 3  of the License, or  (at your
+%    option) any later version.
+%
+%    STK is distributed  in the hope that it will  be useful, but WITHOUT
+%    ANY WARRANTY;  without even the implied  warranty of MERCHANTABILITY
+%    or FITNESS  FOR A  PARTICULAR PURPOSE.  See  the GNU  General Public
+%    License for more details.
+%
+%    You should  have received a copy  of the GNU  General Public License
+%    along with STK.  If not, see <http://www.gnu.org/licenses/>.
+
+function K = stk_nullcov (param, x1, x2, diff, pairwise)  %#ok<INUSL>
+
+% Number of evaluations points
+n1 = size (x1, 1);
+if (nargin > 2) && (~ isempty (x2))
+    n2 = size (x2, 1);
+else
+    n2 = n1;
+end
+
+% Default value for 'pairwise' (arg #5): false
+pairwise = (nargin > 4) && pairwise;
+assert ((n1 == n2) || (~ pairwise));
+
+% Return a matrix of zeros
+if pairwise
+    K = zeros (n1, 1);
+else
+    K = zeros (n1, n2);
+end
+
+end % function

--- a/model/prior_struct/stk_covmat_noise.m
+++ b/model/prior_struct/stk_covmat_noise.m
@@ -34,7 +34,18 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function K = stk_covmat_noise (model, x1, x2, diff, pairwise)
+function K = stk_covmat_noise (model, varargin)
+
+if stk_isnoisy (model)
+    K = stk_covmat_noise_ (model, varargin{:});
+else
+    K = stk_nullcov ([], varargin{:});
+end
+
+end % function
+
+
+function K = stk_covmat_noise_ (model, x1, x2, diff, pairwise)
 
 % Number of evaluations points
 n1 = size (x1, 1);
@@ -53,7 +64,7 @@ if nargin < 4,  diff = -1;  end
 pairwise = (nargin > 4) && pairwise;
 assert ((n1 == n2) || (~ pairwise));
 
-if autocov && (diff ~= 0) && (stk_isnoisy (model))
+if autocov && (diff ~= 0)
 
     if ~ isnumeric (model.lognoisevariance)
 
@@ -120,11 +131,9 @@ if autocov && (diff ~= 0) && (stk_isnoisy (model))
 else  % Return a null matrix
 
     % There are several cases where we return a null matrix:
-    % a) autocov is false: we are actually computing a *cross*-covariance
-    %    matrix.
-    % b) diff = 0: derivative with respect to a parameter that does not
-    %    modify the covariance matrix of the noise.
-    % c) we are in the noiseless case.
+    % a) autocov is false: we are actually computing a *cross*-covariance matrix
+    % b) diff = 0: derivative with respect to a parameter that does not modify
+    %    the covariance matrix of the noise
 
     if pairwise
         K = zeros (n1, 1);


### PR DESCRIPTION
`stk_nullcov.m`: New function, which computes a null covariance matrix
* `stk_nullcov.m`: New function, which computes a null covariance matrix.
* `model/prior_struct/stk_covmat_noise.m`: Use `stk_nullcov`.
* `admin/octpkg/INDEX`: Update Octave package index.
* `NEWS.md`: Advertise the change.