### PR TITLE
@stk_lm_: Base class for @tk_lm_* objects

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,21 @@
+2023-09-18  Julien Bect  <julien.bect@centralesupelec.fr>
+
+	@stk_lm_: Base class for @tk_lm_* objects
+
+	* lm/@stk_lm_/stk_lm_.m: Constructor.
+	* lm/@stk_lm_/cat.m: Overload base function.
+	* lm/@stk_lm_/disp.m: Overload base function.
+	* lm/@stk_lm_/horzcat.m: Overload base function.
+	* lm/@stk_lm_affine/stk_lm_affine.m: Derive from base class.
+	* lm/@stk_lm_constant/stk_lm_constant.m: Idem.
+	* lm/@stk_lm_cubic/stk_lm_cubic.m: Idem.
+	* lm/@stk_lm_matrix/stk_lm_matrix.m: Idem.
+	* lm/@stk_lm_null/stk_lm_null.m: Idem.
+	* lm/@stk_lm_quadratic/stk_lm_quadratic.m: Idem.
+	* admin/octpkg/INDEX: Update Octave package index.
+
+	[Changes imported manually from branch `lm-param`, written in 2021.]
+
 2023-09-12  Julien Bect  <julien.bect@centralesupelec.fr>
 
 	Remove deprecated stk_sf_*.m functions

--- a/admin/octpkg/INDEX
+++ b/admin/octpkg/INDEX
@@ -180,6 +180,10 @@ Model components: linear model objects
  @stk_lm_null/stk_lm_null
  @stk_lm_quadratic/stk_lm_quadratic
  stk_lm_polynomial
+#@stk_lm_/stk_lm_                                             [internal]
+#@stk_lm_/cat                                                 [overload base]
+#@stk_lm_/disp                                                [overload base]
+#@stk_lm_/horzcat                                             [overload base]
 #@stk_lm_affine/feval                                         [overload base]
 #@stk_lm_constant/feval                                       [overload base]
 #@stk_lm_cubic/feval                                          [overload base]

--- a/lm/@stk_lm_/cat.m
+++ b/lm/@stk_lm_/cat.m
@@ -1,13 +1,8 @@
-% STK_LM_AFFINE creates an affine linear model object
-%
-% CALL: LM = STK_LM_AFFINE ()
-%
-%    creates an affine linear model object LM.
+% CAT [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
-%    Copyright (C) 2012-2014 SUPELEC
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -16,7 +11,7 @@
 %    This file is part of
 %
 %            STK: a Small (Matlab/Octave) Toolbox for Kriging
-%               (https://github.com/stk-kriging/stk/)
+%                 (https://github.com/stk-kriging/stk/)
 %
 %    STK is free software: you can redistribute it and/or modify it under
 %    the terms of the GNU General Public License as published by the Free
@@ -31,11 +26,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function lm = stk_lm_affine ()
+function varargout = cat (dim, varargin)  %#ok<STOUT,INUSD>
 
-lm = class (struct (), 'stk_lm_affine', stk_lm_ ());
+stk_error (['Arrays of linear model objects are not supported. ', ...
+    'Use cell arrays instead.'], 'IllegalOperation');
 
-end  % function stk_lm_affine
+% FIXME: Implement horizontal concatenation, which makes sense
 
-
-%!test stk_test_class ('stk_lm_affine')
+end % function

--- a/lm/@stk_lm_/disp.m
+++ b/lm/@stk_lm_/disp.m
@@ -1,13 +1,8 @@
-% STK_LM_AFFINE creates an affine linear model object
-%
-% CALL: LM = STK_LM_AFFINE ()
-%
-%    creates an affine linear model object LM.
+% DISP [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
-%    Copyright (C) 2012-2014 SUPELEC
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -16,7 +11,7 @@
 %    This file is part of
 %
 %            STK: a Small (Matlab/Octave) Toolbox for Kriging
-%               (https://github.com/stk-kriging/stk/)
+%                 (https://github.com/stk-kriging/stk/)
 %
 %    STK is free software: you can redistribute it and/or modify it under
 %    the terms of the GNU General Public License as published by the Free
@@ -31,11 +26,8 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function lm = stk_lm_affine ()
+function disp (lm)
 
-lm = class (struct (), 'stk_lm_affine', stk_lm_ ());
+fprintf ('<%s>\n', stk_sprintf_sizetype (lm));
 
-end  % function stk_lm_affine
-
-
-%!test stk_test_class ('stk_lm_affine')
+end % function

--- a/lm/@stk_lm_/horzcat.m
+++ b/lm/@stk_lm_/horzcat.m
@@ -1,13 +1,8 @@
-% STK_LM_AFFINE creates an affine linear model object
-%
-% CALL: LM = STK_LM_AFFINE ()
-%
-%    creates an affine linear model object LM.
+% HORZCAT [overload base function]
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
-%    Copyright (C) 2012-2014 SUPELEC
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -16,7 +11,7 @@
 %    This file is part of
 %
 %            STK: a Small (Matlab/Octave) Toolbox for Kriging
-%               (https://github.com/stk-kriging/stk/)
+%                 (https://github.com/stk-kriging/stk/)
 %
 %    STK is free software: you can redistribute it and/or modify it under
 %    the terms of the GNU General Public License as published by the Free
@@ -31,11 +26,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function lm = stk_lm_affine ()
+function varargout = horzcat (varargin)  %#ok<STOUT>
 
-lm = class (struct (), 'stk_lm_affine', stk_lm_ ());
+stk_error (['Arrays of linear model objects are not supported. ', ...
+    'Use cell arrays instead.'], 'IllegalOperation');
 
-end  % function stk_lm_affine
+% FIXME: Implement horizontal concatenation, which makes sense
 
-
-%!test stk_test_class ('stk_lm_affine')
+end % function

--- a/lm/@stk_lm_/stk_lm_.m
+++ b/lm/@stk_lm_/stk_lm_.m
@@ -1,13 +1,11 @@
-% STK_LM_AFFINE creates an affine linear model object
+% STK_LM_ [internal]
 %
-% CALL: LM = STK_LM_AFFINE ()
+% Base class for all lm objects.
 %
-%    creates an affine linear model object LM.
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
-%    Copyright (C) 2012-2014 SUPELEC
+%    Copyright (C) 2021 CentraleSupelec
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
 
@@ -16,7 +14,7 @@
 %    This file is part of
 %
 %            STK: a Small (Matlab/Octave) Toolbox for Kriging
-%               (https://github.com/stk-kriging/stk/)
+%                 (https://github.com/stk-kriging/stk/)
 %
 %    STK is free software: you can redistribute it and/or modify it under
 %    the terms of the GNU General Public License as published by the Free
@@ -31,11 +29,11 @@
 %    You should  have received a copy  of the GNU  General Public License
 %    along with STK.  If not, see <http://www.gnu.org/licenses/>.
 
-function lm = stk_lm_affine ()
+function lm = stk_lm_ ()
 
-lm = class (struct (), 'stk_lm_affine', stk_lm_ ());
+lm = class (struct (), 'stk_lm_', stk_model_ ());
 
-end  % function stk_lm_affine
+end % function
 
 
-%!test stk_test_class ('stk_lm_affine')
+%!test stk_test_class ('stk_lm_')

--- a/lm/@stk_lm_constant/stk_lm_constant.m
+++ b/lm/@stk_lm_constant/stk_lm_constant.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_constant ()
 
-lm = class (struct (), 'stk_lm_constant');
+lm = class (struct (), 'stk_lm_constant', stk_lm_ ());
 
 end % function
 

--- a/lm/@stk_lm_cubic/stk_lm_cubic.m
+++ b/lm/@stk_lm_cubic/stk_lm_cubic.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_cubic ()
 
-lm = class (struct (), 'stk_lm_cubic');
+lm = class (struct (), 'stk_lm_cubic', stk_lm_ ());
 
 end % function
 

--- a/lm/@stk_lm_matrix/stk_lm_matrix.m
+++ b/lm/@stk_lm_matrix/stk_lm_matrix.m
@@ -8,7 +8,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -41,7 +41,7 @@ else
     lm = struct ('data', data);
 end
 
-lm = class (lm, 'stk_lm_matrix');
+lm = class (lm, 'stk_lm_matrix', stk_lm_ ());
 
 end % function
 

--- a/lm/@stk_lm_null/stk_lm_null.m
+++ b/lm/@stk_lm_null/stk_lm_null.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_null ()
 
-lm = class (struct (), 'stk_lm_null');
+lm = class (struct (), 'stk_lm_null', stk_lm_ ());
 
 end % function
 

--- a/lm/@stk_lm_quadratic/stk_lm_quadratic.m
+++ b/lm/@stk_lm_quadratic/stk_lm_quadratic.m
@@ -6,7 +6,7 @@
 
 % Copyright Notice
 %
-%    Copyright (C) 2017, 2018 CentraleSupelec
+%    Copyright (C) 2017, 2018, 2021 CentraleSupelec
 %    Copyright (C) 2012-2014 SUPELEC
 %
 %    Author:  Julien Bect  <julien.bect@centralesupelec.fr>
@@ -33,7 +33,7 @@
 
 function lm = stk_lm_quadratic ()
 
-lm = class (struct (), 'stk_lm_quadratic');
+lm = class (struct (), 'stk_lm_quadratic', stk_lm_ ());
 
 end % function
 


### PR DESCRIPTION
* `lm/@stk_lm_/stk_lm_.m`: Constructor.
* `lm/@stk_lm_/cat.m`: Overload base function.
* `lm/@stk_lm_/disp.m`: Overload base function.
* `lm/@stk_lm_/horzcat.m`: Overload base function.
* `lm/@stk_lm_affine/stk_lm_affine.m`: Derive from base class.
* `lm/@stk_lm_constant/stk_lm_constant.m`: Idem.
* `lm/@stk_lm_cubic/stk_lm_cubic.m`: Idem.
* `lm/@stk_lm_matrix/stk_lm_matrix.m`: Idem.
* `lm/@stk_lm_null/stk_lm_null.m`: Idem.
* `lm/@stk_lm_quadratic/stk_lm_quadratic.m`: Idem.
* `admin/octpkg/INDEX`: Update Octave package index.

[Changes imported manually from branch `lm-param`, written in 2021.]